### PR TITLE
Add super admin dashboard and module toggling with audit log

### DIFF
--- a/app/Http/Controllers/SuperAdminDashboardController.php
+++ b/app/Http/Controllers/SuperAdminDashboardController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tenant;
+use App\Models\TenantModule;
+use App\Models\AuditLog;
+use Illuminate\Support\Facades\DB;
+
+class SuperAdminDashboardController extends Controller
+{
+    public function index()
+    {
+        $tenants = Tenant::with(['modules' => function ($q) {
+            $q->where('enabled', true);
+        }])->get();
+
+        $moduleUsage = TenantModule::select('module', DB::raw('count(*) as count'))
+            ->where('enabled', true)
+            ->groupBy('module')
+            ->pluck('count', 'module');
+
+        $recentLogs = AuditLog::latest()->limit(10)->get();
+
+        return view('admin.dashboard', compact('tenants', 'moduleUsage', 'recentLogs'));
+    }
+}

--- a/app/Http/Controllers/TenantModuleController.php
+++ b/app/Http/Controllers/TenantModuleController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tenant;
+use App\Support\ModuleManager;
+use Illuminate\Http\Request;
+
+class TenantModuleController extends Controller
+{
+    public function toggle(Request $request, Tenant $tenant, string $module, ModuleManager $manager)
+    {
+        $enabled = $request->boolean('enabled');
+        $manager->toggle($tenant, $module, $enabled);
+
+        return redirect()->route('admin.dashboard');
+    }
+}

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AuditLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['tenant_id', 'action', 'meta'];
+
+    protected $casts = [
+        'meta' => 'array',
+    ];
+}

--- a/app/Models/SystemSetting.php
+++ b/app/Models/SystemSetting.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SystemSetting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['key', 'value', 'scope'];
+
+    protected $casts = [
+        'value' => 'array',
+    ];
+}

--- a/app/Support/ModuleManager.php
+++ b/app/Support/ModuleManager.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Tenant;
+use App\Models\TenantModule;
+use App\Models\AuditLog;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Support\Facades\DB;
+
+class ModuleManager
+{
+    /**
+     * Map of module dependencies.
+     * @var array<string,array<int,string>>
+     */
+    protected array $dependencies = [
+        'analytics' => ['billing'],
+        'billing' => [],
+    ];
+
+    public function toggle(Tenant $tenant, string $module, bool $enabled): TenantModule
+    {
+        if ($enabled) {
+            foreach ($this->dependencies[$module] ?? [] as $dependency) {
+                $active = $tenant->modules()->where('module', $dependency)->where('enabled', true)->exists();
+                if (! $active) {
+                    throw ValidationException::withMessages([
+                        'module' => "Missing dependency: {$dependency}",
+                    ]);
+                }
+            }
+        }
+
+        $tenantModule = $tenant->modules()->updateOrCreate(
+            ['module' => $module],
+            ['enabled' => $enabled]
+        );
+
+        AuditLog::create([
+            'tenant_id' => $tenant->id,
+            'action' => 'module.toggled',
+            'meta' => [
+                'module' => $module,
+                'enabled' => $enabled,
+            ],
+        ]);
+
+        return $tenantModule;
+    }
+}

--- a/app/Support/SystemSettings.php
+++ b/app/Support/SystemSettings.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\SystemSetting;
+
+class SystemSettings
+{
+    public function get(string $key, $default = null, ?string $scope = null)
+    {
+        return optional(SystemSetting::where('key', $key)->where('scope', $scope)->first())->value ?? $default;
+    }
+
+    public function set(string $key, $value, ?string $scope = null): SystemSetting
+    {
+        return SystemSetting::updateOrCreate(
+            ['key' => $key, 'scope' => $scope],
+            ['value' => $value]
+        );
+    }
+}

--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TenantFactory extends Factory
+{
+    protected $model = Tenant::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company,
+            'domain' => $this->faker->domainName,
+            'config_json' => [],
+        ];
+    }
+}

--- a/database/migrations/0001_01_01_000008_create_audit_logs_table.php
+++ b/database/migrations/0001_01_01_000008_create_audit_logs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('action');
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/database/migrations/0001_01_01_000009_create_system_settings_table.php
+++ b/database/migrations/0001_01_01_000009_create_system_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('system_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key');
+            $table->json('value')->nullable();
+            $table->string('scope')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('system_settings');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,22 @@
+<h1>Super Admin Dashboard</h1>
+
+<h2>Tenants</h2>
+<ul>
+@foreach($tenants as $tenant)
+    <li>{{ $tenant->name }}: {{ implode(', ', $tenant->modules->pluck('module')->toArray()) }}</li>
+@endforeach
+</ul>
+
+<h2>Module Usage</h2>
+<ul>
+@foreach($moduleUsage as $module => $count)
+    <li>{{ $module }}: {{ $count }}</li>
+@endforeach
+</ul>
+
+<h2>Recent Audit Logs</h2>
+<ul>
+@foreach($recentLogs as $log)
+    <li>{{ $log->action }} - {{ $log->meta['module'] ?? '' }} - {{ $log->created_at }}</li>
+@endforeach
+</ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,15 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\SuperAdminDashboardController;
+use App\Http\Controllers\TenantModuleController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/admin', [SuperAdminDashboardController::class, 'index'])
+    ->name('admin.dashboard');
+
+Route::post('/admin/tenants/{tenant}/modules/{module}', [TenantModuleController::class, 'toggle'])
+    ->name('admin.modules.toggle');

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Application;
+
+trait CreatesApplication
+{
+    public function createApplication(): Application
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+        $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/ModuleManagerTest.php
+++ b/tests/Feature/ModuleManagerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\Tenant;
+use App\Support\ModuleManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class ModuleManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_prevents_enabling_without_dependencies(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $manager = new ModuleManager();
+
+        $this->expectException(ValidationException::class);
+        $manager->toggle($tenant, 'analytics', true);
+    }
+
+    public function test_logs_module_toggles(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $manager = new ModuleManager();
+
+        $manager->toggle($tenant, 'billing', true);
+
+        $this->assertDatabaseHas('tenant_modules', [
+            'tenant_id' => $tenant->id,
+            'module' => 'billing',
+            'enabled' => true,
+        ]);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'tenant_id' => $tenant->id,
+            'action' => 'module.toggled',
+        ]);
+    }
+}

--- a/tests/Feature/SuperAdminDashboardTest.php
+++ b/tests/Feature/SuperAdminDashboardTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tenant;
+use App\Support\ModuleManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SuperAdminDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_displays_tenants_and_modules(): void
+    {
+        $tenant = Tenant::factory()->create(['name' => 'Acme']);
+        $manager = new ModuleManager();
+        $manager->toggle($tenant, 'billing', true);
+
+        $response = $this->get('/admin');
+        $response->assertStatus(200);
+        $response->assertSee('Acme');
+        $response->assertSee('billing');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }

--- a/tests/Unit/SystemSettingsTest.php
+++ b/tests/Unit/SystemSettingsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\SystemSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SystemSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_set_and_get_values(): void
+    {
+        $settings = new SystemSettings();
+        $settings->set('currency', ['code' => 'USD']);
+
+        $this->assertSame(['code' => 'USD'], $settings->get('currency'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add SuperAdminDashboardController and view to list tenants, active modules, usage counts, and recent audit logs
- Implement ModuleManager service with dependency checks and audit logging
- Introduce SystemSettings service and models for global configuration
- Provide tests for module toggling, dashboard display, and system settings

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68be9d25316483329ba3666fc22888b3