### PR TITLE
feat: add event bus retry orchestration

### DIFF
--- a/app/Jobs/DispatchDomainEvent.php
+++ b/app/Jobs/DispatchDomainEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Support\EventBus;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Redis;
+
+class DispatchDomainEvent implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        private string $event,
+        private array $payload = [],
+        private int $attempt = 1,
+        private int $maxAttempts = 3,
+        private array $backoff = [1, 5, 10]
+    ) {}
+
+    public function handle(EventBus $bus): void
+    {
+        try {
+            $bus->dispatchNow($this->event, $this->payload);
+            Log::info('event.published', ['event' => $this->event, 'attempt' => $this->attempt]);
+        } catch (\Throwable $e) {
+            if ($this->attempt < $this->maxAttempts) {
+                $delay = $this->backoff[$this->attempt - 1] ?? end($this->backoff);
+                $this->attempt++;
+                Log::warning('event.retry', [
+                    'event' => $this->event,
+                    'attempt' => $this->attempt,
+                    'delay' => $delay,
+                    'error' => $e->getMessage(),
+                ]);
+                $this->release($delay);
+            } else {
+                Redis::rpush('events:dlq', json_encode([
+                    'event' => $this->event,
+                    'payload' => $this->payload,
+                    'error' => $e->getMessage(),
+                ]));
+                Log::error('event.dead_lettered', [
+                    'event' => $this->event,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+    }
+}

--- a/app/Support/EventBus.php
+++ b/app/Support/EventBus.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use App\Jobs\DispatchDomainEvent;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class EventBus
@@ -9,6 +10,11 @@ class EventBus
     public function __construct(private Dispatcher $dispatcher) {}
 
     public function publish(string $event, array $payload = []): void
+    {
+        DispatchDomainEvent::dispatch($event, $payload);
+    }
+
+    public function dispatchNow(string $event, array $payload = []): void
     {
         $this->dispatcher->dispatch($event, $payload);
     }

--- a/docs/events-and-retries.md
+++ b/docs/events-and-retries.md
@@ -1,0 +1,23 @@
+# Domain Events & Retry Flows
+
+## Supported Events
+
+The orchestrator consumes and publishes domain topics across modules. Initial topics include:
+
+- `tenant.created`
+- `tenant.activated`
+- `user.invited`
+- `module.toggled`
+- `tenant.suspended`
+
+These events are dispatched through the internal `EventBus` which fans out to module listeners.
+
+## Retry & Dead-Letter Strategy
+
+1. `EventBus::publish()` enqueues `DispatchDomainEvent`.
+2. The job attempts to deliver the event and logs telemetry using `event.published`.
+3. On failure, it retries with exponential backoff `(1s, 5s, 10s)` and logs `event.retry`.
+4. After three failed attempts the payload is pushed to the Redis list `events:dlq` and an
+   `event.dead_lettered` log entry is emitted for investigation.
+
+This flow ensures reliable delivery and observability for all domain events.


### PR DESCRIPTION
## Summary
- queue domain events through `DispatchDomainEvent` job with retry/backoff and DLQ telemetry
- update `EventBus` to publish asynchronously and dispatch synchronously
- document supported events and retry flow

## Testing
- `vendor/bin/pint app/Support/EventBus.php app/Jobs/DispatchDomainEvent.php`
- `php -d memory_limit=512M vendor/bin/phpstan analyse app --no-progress`
- `./vendor/bin/pest -q` *(fails: No such file or directory)*
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68be9e9f10648332a2db34f9dc8400d7