### PR TITLE
feat: add integration configs and webhook infrastructure

### DIFF
--- a/app/Console/Commands/RotateWebhookKey.php
+++ b/app/Console/Commands/RotateWebhookKey.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\IntegrationConfig;
+use App\Models\WebhookKey;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class RotateWebhookKey extends Command
+{
+    protected $signature = 'webhook:rotate {service} {tenant_id?}';
+
+    protected $description = 'Rotate webhook signing keys for a service';
+
+    public function handle(): int
+    {
+        $service = $this->argument('service');
+        $tenantId = $this->argument('tenant_id');
+
+        $tenants = $tenantId
+            ? collect([$tenantId])
+            : IntegrationConfig::where('service', $service)->pluck('tenant_id');
+
+        foreach ($tenants as $tid) {
+            WebhookKey::where('tenant_id', $tid)
+                ->where('service', $service)
+                ->update(['active' => false]);
+
+            WebhookKey::create([
+                'tenant_id' => $tid,
+                'service' => $service,
+                'key' => Str::random(40),
+                'active' => true,
+            ]);
+        }
+
+        $this->info('Keys rotated.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/IntegrationManagerController.php
+++ b/app/Http/Controllers/IntegrationManagerController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\IntegrationConfig;
+use App\Models\WebhookLog;
+use Illuminate\Http\Request;
+
+class IntegrationManagerController extends Controller
+{
+    public function index()
+    {
+        $configs = IntegrationConfig::with('activeKey')->get();
+        $logs = WebhookLog::latest()->limit(50)->get();
+
+        return view('admin.integrations.index', compact('configs', 'logs'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'tenant_id' => 'required|exists:tenants,id',
+            'service' => 'required|string',
+            'config_json' => 'nullable|array',
+        ]);
+
+        IntegrationConfig::updateOrCreate(
+            ['tenant_id' => $data['tenant_id'], 'service' => $data['service']],
+            ['config_json' => $data['config_json'] ?? null]
+        );
+
+        return redirect()->route('admin.integrations.index');
+    }
+}

--- a/app/Jobs/SendWebhook.php
+++ b/app/Jobs/SendWebhook.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WebhookKey;
+use App\Models\WebhookLog;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class SendWebhook implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(private WebhookLog $log, private int $attempt = 1, private int $maxAttempts = 5) {}
+
+    public function handle(): void
+    {
+        $key = WebhookKey::where('tenant_id', $this->log->tenant_id)
+            ->where('service', $this->log->service)
+            ->where('active', true)
+            ->latest()
+            ->first();
+
+        if (! $key) {
+            $this->log->update([
+                'status' => 'failed',
+                'attempts' => $this->attempt,
+                'last_error' => 'missing_key',
+            ]);
+
+            return;
+        }
+
+        $payload = $this->log->payload;
+        $signature = hash_hmac('sha256', json_encode($payload), $key->key);
+
+        try {
+            $response = Http::withHeaders([
+                'X-Signature' => $signature,
+            ])->post($this->log->url, $payload);
+
+            $this->log->update([
+                'headers' => ['X-Signature' => $signature],
+                'response_code' => $response->status(),
+                'response_body' => $response->body(),
+                'attempts' => $this->attempt,
+                'status' => $response->successful() ? 'success' : 'failed',
+                'last_error' => $response->successful() ? null : $response->body(),
+            ]);
+
+            if (! $response->successful()) {
+                $this->retry();
+            }
+        } catch (\Throwable $e) {
+            $this->log->update([
+                'attempts' => $this->attempt,
+                'status' => 'failed',
+                'last_error' => $e->getMessage(),
+            ]);
+            $this->retry();
+        }
+    }
+
+    private function retry(): void
+    {
+        if ($this->attempt < $this->maxAttempts) {
+            $delay = $this->attempt * 2;
+            self::dispatch($this->log, $this->attempt + 1, $this->maxAttempts)->delay($delay);
+            Log::warning('webhook.retry', ['log_id' => $this->log->id, 'attempt' => $this->attempt + 1]);
+        } else {
+            Log::error('webhook.failed', ['log_id' => $this->log->id]);
+        }
+    }
+}

--- a/app/Models/IntegrationConfig.php
+++ b/app/Models/IntegrationConfig.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class IntegrationConfig extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['tenant_id', 'service', 'config_json'];
+
+    protected $casts = [
+        'config_json' => 'array',
+    ];
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    public function activeKey()
+    {
+        return $this->hasOne(WebhookKey::class)->where('active', true);
+    }
+}

--- a/app/Models/WebhookKey.php
+++ b/app/Models/WebhookKey.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class WebhookKey extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['tenant_id', 'service', 'key', 'active', 'expires_at'];
+
+    protected $casts = [
+        'active' => 'boolean',
+        'expires_at' => 'datetime',
+    ];
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}

--- a/app/Models/WebhookLog.php
+++ b/app/Models/WebhookLog.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class WebhookLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'service',
+        'url',
+        'payload',
+        'headers',
+        'attempts',
+        'status',
+        'last_error',
+        'response_code',
+        'response_body',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'headers' => 'array',
+    ];
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}

--- a/app/Support/Webhook.php
+++ b/app/Support/Webhook.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Support;
+
+use App\Jobs\SendWebhook;
+use App\Models\WebhookLog;
+
+class Webhook
+{
+    public static function send(int $tenantId, string $service, string $url, array $payload): WebhookLog
+    {
+        $log = WebhookLog::create([
+            'tenant_id' => $tenantId,
+            'service' => $service,
+            'url' => $url,
+            'payload' => $payload,
+        ]);
+
+        SendWebhook::dispatch($log);
+
+        return $log;
+    }
+}

--- a/database/migrations/2024_01_01_100001_create_integration_configs_table.php
+++ b/database/migrations/2024_01_01_100001_create_integration_configs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('integration_configs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->string('service');
+            $table->json('config_json')->nullable();
+            $table->timestamps();
+            $table->unique(['tenant_id', 'service']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('integration_configs');
+    }
+};

--- a/database/migrations/2024_01_01_100002_create_webhook_keys_table.php
+++ b/database/migrations/2024_01_01_100002_create_webhook_keys_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_keys', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->string('service');
+            $table->string('key');
+            $table->boolean('active')->default(true);
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+            $table->unique(['tenant_id', 'service', 'key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_keys');
+    }
+};

--- a/database/migrations/2024_01_01_100003_create_webhook_logs_table.php
+++ b/database/migrations/2024_01_01_100003_create_webhook_logs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->string('service');
+            $table->string('url');
+            $table->json('payload');
+            $table->json('headers')->nullable();
+            $table->integer('attempts')->default(0);
+            $table->string('status')->default('pending');
+            $table->text('last_error')->nullable();
+            $table->integer('response_code')->nullable();
+            $table->text('response_body')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_logs');
+    }
+};

--- a/resources/views/admin/integrations/index.blade.php
+++ b/resources/views/admin/integrations/index.blade.php
@@ -1,0 +1,24 @@
+<h1>Integration Manager</h1>
+
+<h2>Add / Update Config</h2>
+<form method="POST" action="{{ route('admin.integrations.store') }}">
+    @csrf
+    <input type="number" name="tenant_id" placeholder="Tenant ID">
+    <input type="text" name="service" placeholder="Service">
+    <textarea name="config_json" placeholder="{\"key\":\"value\"}"></textarea>
+    <button type="submit">Save</button>
+</form>
+
+<h2>Configs</h2>
+<ul>
+@foreach($configs as $config)
+    <li>Tenant {{ $config->tenant_id }} - {{ $config->service }}</li>
+@endforeach
+</ul>
+
+<h2>Recent Webhook Logs</h2>
+<ul>
+@foreach($logs as $log)
+    <li>{{ $log->service }} - {{ $log->status }} (Attempts: {{ $log->attempts }})</li>
+@endforeach
+</ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\IntegrationManagerController;
 use App\Http\Controllers\SuperAdminDashboardController;
 use App\Http\Controllers\TenantModuleController;
+use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
@@ -13,3 +14,8 @@ Route::get('/admin', [SuperAdminDashboardController::class, 'index'])
 
 Route::post('/admin/tenants/{tenant}/modules/{module}', [TenantModuleController::class, 'toggle'])
     ->name('admin.modules.toggle');
+
+Route::get('/admin/integrations', [IntegrationManagerController::class, 'index'])
+    ->name('admin.integrations.index');
+Route::post('/admin/integrations', [IntegrationManagerController::class, 'store'])
+    ->name('admin.integrations.store');

--- a/tests/Feature/WebhookTest.php
+++ b/tests/Feature/WebhookTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SendWebhook;
+use App\Models\Tenant;
+use App\Models\WebhookKey;
+use App\Models\WebhookLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class WebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sends_signed_webhooks_and_logs_success(): void
+    {
+        $tenant = Tenant::factory()->create();
+
+        WebhookKey::create([
+            'tenant_id' => $tenant->id,
+            'service' => 'test',
+            'key' => 'secret',
+        ]);
+
+        Http::fake([
+            'example.com/*' => Http::response('ok', 200),
+        ]);
+
+        $log = WebhookLog::create([
+            'tenant_id' => $tenant->id,
+            'service' => 'test',
+            'url' => 'https://example.com/hook',
+            'payload' => ['a' => 1],
+        ]);
+
+        (new SendWebhook($log))->handle();
+
+        $log->refresh();
+
+        $this->assertEquals('success', $log->status);
+        $this->assertEquals(200, $log->response_code);
+    }
+}


### PR DESCRIPTION
## Summary
- add per-tenant integration_configs and webhook key/log tables
- implement signed webhook dispatch with retries and key rotation command
- add admin integration manager dashboard

## Testing
- `vendor/bin/pint app/Console/Commands/RotateWebhookKey.php app/Http/Controllers/IntegrationManagerController.php app/Jobs/SendWebhook.php app/Models/IntegrationConfig.php app/Models/WebhookKey.php app/Models/WebhookLog.php app/Support/Webhook.php routes/web.php database/migrations/2024_01_01_100001_create_integration_configs_table.php database/migrations/2024_01_01_100002_create_webhook_keys_table.php database/migrations/2024_01_01_100003_create_webhook_logs_table.php tests/Feature/WebhookTest.php`
- `vendor/bin/phpstan analyse app tests/Feature/WebhookTest.php --no-progress --memory-limit=512M`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68bec233d30c8332b62371ef31614041