### PR TITLE
feat: add basic billing infrastructure

### DIFF
--- a/app/Console/Commands/ProcessBilling.php
+++ b/app/Console/Commands/ProcessBilling.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Payment;
+use App\Models\Subscription;
+use App\Notifications\PaymentOverdue;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Notification;
+
+class ProcessBilling extends Command
+{
+    protected $signature = 'billing:process';
+
+    protected $description = 'Generate payments and notify overdue subscriptions';
+
+    public function handle(): int
+    {
+        Subscription::query()
+            ->where('status', 'active')
+            ->whereNotNull('next_billing_at')
+            ->where('next_billing_at', '<=', now())
+            ->each(function (Subscription $subscription) {
+                Payment::create([
+                    'tenant_id' => $subscription->tenant_id,
+                    'subscription_id' => $subscription->id,
+                    'amount_cents' => $subscription->amount_cents,
+                    'currency' => $subscription->currency,
+                    'status' => 'due',
+                    'due_at' => $subscription->next_billing_at,
+                ]);
+
+                $subscription->update(['status' => 'past_due']);
+            });
+
+        Subscription::query()
+            ->where('status', 'past_due')
+            ->each(function (Subscription $subscription) {
+                Notification::route('mail', $subscription->user_id)
+                    ->notify(new PaymentOverdue($subscription));
+            });
+
+        $this->info('Billing processed.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -9,7 +9,7 @@ class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule): void
     {
-        //
+        $schedule->command('billing:process')->daily();
     }
 
     protected function commands(): void

--- a/app/Http/Controllers/BillingDashboardController.php
+++ b/app/Http/Controllers/BillingDashboardController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Payment;
+use App\Models\Subscription;
+use Illuminate\View\View;
+
+class BillingDashboardController extends Controller
+{
+    public function index(): View
+    {
+        $subscriptions = Subscription::all();
+        $payments = Payment::latest()->get();
+
+        return view('billing.dashboard', compact('subscriptions', 'payments'));
+    }
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Payment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'subscription_id',
+        'amount_cents',
+        'currency',
+        'provider',
+        'reference',
+        'status',
+        'due_at',
+        'paid_at',
+    ];
+
+    protected $casts = [
+        'due_at' => 'datetime',
+        'paid_at' => 'datetime',
+    ];
+
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(Subscription::class);
+    }
+}

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Plan extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'name',
+        'price_cents',
+        'currency',
+        'interval',
+        'features',
+    ];
+
+    protected $casts = [
+        'features' => 'array',
+    ];
+}

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Subscription extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'user_id',
+        'plan_id',
+        'amount_cents',
+        'currency',
+        'status',
+        'starts_at',
+        'ends_at',
+        'trial_ends_at',
+        'next_billing_at',
+    ];
+
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+        'trial_ends_at' => 'datetime',
+        'next_billing_at' => 'datetime',
+    ];
+
+    public function plan(): BelongsTo
+    {
+        return $this->belongsTo(Plan::class);
+    }
+}

--- a/app/Notifications/PaymentOverdue.php
+++ b/app/Notifications/PaymentOverdue.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Subscription;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PaymentOverdue extends Notification
+{
+    use Queueable;
+
+    public function __construct(private Subscription $subscription) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Payment Overdue')
+            ->line('Your subscription payment is overdue.')
+            ->action('Pay Now', url('/billing'));
+    }
+}

--- a/app/Support/BillingService.php
+++ b/app/Support/BillingService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Plan;
+use App\Models\Subscription;
+use Carbon\Carbon;
+
+class BillingService
+{
+    public function __construct(private CurrencyConverter $converter) {}
+
+    /**
+     * Calculate prorated amount when switching plan.
+     */
+    public function prorate(Subscription $subscription, Plan $newPlan, Carbon $changeDate): int
+    {
+        $currentPlan = $subscription->plan;
+        $cycleEnds = $subscription->next_billing_at ?? $changeDate;
+        $totalDays = $subscription->starts_at?->diffInDays($cycleEnds) ?: 1;
+        $remainingDays = $changeDate->diffInDays($cycleEnds, false);
+
+        $currentAmount = $subscription->amount_cents;
+        $newAmount = $this->converter->convert($newPlan->price_cents, $newPlan->currency, $subscription->currency);
+
+        $unusedValue = (int) round($currentAmount * max($remainingDays, 0) / $totalDays);
+
+        return $newAmount - $unusedValue;
+    }
+}

--- a/app/Support/CurrencyConverter.php
+++ b/app/Support/CurrencyConverter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Support;
+
+class CurrencyConverter
+{
+    /**
+     * Convert minor unit amount between currencies.
+     */
+    public function convert(int $amount, string $from, string $to): int
+    {
+        if ($from === $to) {
+            return $amount;
+        }
+
+        // Demo rates; in real implementation integrate with FX service.
+        $rates = [
+            'USD' => ['EUR' => 0.9],
+            'EUR' => ['USD' => 1.11],
+        ];
+
+        $rate = $rates[$from][$to] ?? 1;
+
+        return (int) round($amount * $rate);
+    }
+}

--- a/database/migrations/2024_01_01_000010_create_plans_table.php
+++ b/database/migrations/2024_01_01_000010_create_plans_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('plans', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id');
+            $table->string('name');
+            $table->unsignedInteger('price_cents');
+            $table->string('currency', 3);
+            $table->string('interval');
+            $table->json('features')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plans');
+    }
+};

--- a/database/migrations/2024_01_01_000011_create_subscriptions_table.php
+++ b/database/migrations/2024_01_01_000011_create_subscriptions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('plan_id');
+            $table->unsignedInteger('amount_cents');
+            $table->string('currency', 3);
+            $table->string('status');
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('next_billing_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/database/migrations/2024_01_01_000012_create_payments_table.php
+++ b/database/migrations/2024_01_01_000012_create_payments_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id');
+            $table->unsignedBigInteger('subscription_id');
+            $table->unsignedInteger('amount_cents');
+            $table->string('currency', 3);
+            $table->string('provider')->nullable();
+            $table->string('reference')->nullable();
+            $table->string('status');
+            $table->timestamp('due_at')->nullable();
+            $table->timestamp('paid_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/resources/views/billing/dashboard.blade.php
+++ b/resources/views/billing/dashboard.blade.php
@@ -1,0 +1,15 @@
+<h1>Billing Dashboard</h1>
+
+<h2>Subscriptions</h2>
+<ul>
+    @foreach($subscriptions as $subscription)
+        <li>{{ $subscription->id }} - {{ $subscription->status }} - {{ $subscription->amount_cents }} {{ $subscription->currency }}</li>
+    @endforeach
+</ul>
+
+<h2>Payments</h2>
+<ul>
+    @foreach($payments as $payment)
+        <li>{{ $payment->id }} - {{ $payment->status }} - {{ $payment->amount_cents }} {{ $payment->currency }}</li>
+    @endforeach
+</ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\BillingDashboardController;
 use App\Http\Controllers\FeatureFlagController;
 use App\Http\Controllers\IntegrationManagerController;
 use App\Http\Controllers\SuperAdminDashboardController;
@@ -13,6 +14,9 @@ Route::get('/', function () {
 
 Route::get('/admin', [SuperAdminDashboardController::class, 'index'])
     ->name('admin.dashboard');
+
+Route::get('/billing', [BillingDashboardController::class, 'index'])
+    ->name('billing.dashboard');
 
 Route::post('/admin/tenants/{tenant}/modules/{module}', [TenantModuleController::class, 'toggle'])
     ->name('admin.modules.toggle');


### PR DESCRIPTION
## Summary
- add migrations for plans, subscriptions, payments
- implement proration and currency conversion services
- introduce billing dashboard and scheduled billing processor

## Testing
- `npm ci`
- `npm run build`
- `vendor/bin/pint -v`
- `vendor/bin/phpstan analyse app --no-progress` (fails: Allowed memory size exhausted)
- `./vendor/bin/pest -q` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68bec4f0cfc88332b69f772d8991a82d