### PR TITLE
feat: add price rule support

### DIFF
--- a/app/Events/PriceRuleApplied.php
+++ b/app/Events/PriceRuleApplied.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\PriceRule;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PriceRuleApplied implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public PriceRule $rule) {}
+
+    public function broadcastOn(): Channel
+    {
+        return new PrivateChannel('tenants.'.$this->rule->tenant_id);
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'price.rule_applied';
+    }
+}

--- a/app/Models/PriceRule.php
+++ b/app/Models/PriceRule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\BelongsToTenant;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PriceRule extends Model
+{
+    use BelongsToTenant, HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'branch_id',
+        'scope',
+        'condition',
+        'formula',
+    ];
+
+    protected $casts = [
+        'condition' => 'array',
+    ];
+}

--- a/app/Services/PricingService.php
+++ b/app/Services/PricingService.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Services;
+
+use App\Events\PriceRuleApplied;
+use App\Models\PriceRule;
+use Carbon\Carbon;
+
+class PricingService
+{
+    public function apply(float $price, int $tenantId, ?int $branchId, int $quantity, ?Carbon $now = null): float
+    {
+        $now = $now ?: now();
+
+        $rules = PriceRule::query()
+            ->where('tenant_id', $tenantId)
+            ->where(function ($q) use ($branchId) {
+                $q->whereNull('branch_id');
+                if ($branchId !== null) {
+                    $q->orWhere('branch_id', $branchId);
+                }
+            })
+            ->get();
+
+        foreach ($rules as $rule) {
+            if ($this->matches($rule, $branchId, $quantity, $now)) {
+                $newPrice = $this->evaluateFormula($rule->formula, $price, $quantity);
+                event(new PriceRuleApplied($rule));
+
+                return $newPrice;
+            }
+        }
+
+        return $price;
+    }
+
+    protected function matches(PriceRule $rule, ?int $branchId, int $quantity, Carbon $now): bool
+    {
+        if ($rule->branch_id && $rule->branch_id !== $branchId) {
+            return false;
+        }
+
+        $condition = $rule->condition ?? [];
+
+        if (isset($condition['time'])) {
+            $start = Carbon::parse($condition['time']['start'] ?? '1900-01-01');
+            $end = Carbon::parse($condition['time']['end'] ?? '2999-12-31');
+            if ($now->lt($start) || $now->gt($end)) {
+                return false;
+            }
+        }
+
+        if (isset($condition['volume'])) {
+            $min = $condition['volume']['min'] ?? 0;
+            $max = $condition['volume']['max'] ?? PHP_INT_MAX;
+            if ($quantity < $min || $quantity > $max) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function evaluateFormula(string $formula, float $price, int $quantity): float
+    {
+        $expression = str_replace(['price', 'qty'], [$price, $quantity], $formula);
+
+        return eval("return {$expression};");
+    }
+}

--- a/database/migrations/2024_01_01_100006_create_price_rules_table.php
+++ b/database/migrations/2024_01_01_100006_create_price_rules_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('price_rules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('branch_id')->nullable()->index();
+            $table->string('scope');
+            $table->json('condition')->nullable();
+            $table->string('formula');
+            $table->timestamps();
+            $table->index(['tenant_id', 'branch_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('price_rules');
+    }
+};

--- a/tests/Unit/PricingServiceTest.php
+++ b/tests/Unit/PricingServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Events\PriceRuleApplied;
+use App\Models\PriceRule;
+use App\Models\Tenant;
+use App\Services\PricingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class PricingServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_applies_rule_and_fires_event(): void
+    {
+        Tenant::factory()->create(['id' => 1]);
+
+        $rule = PriceRule::create([
+            'tenant_id' => 1,
+            'branch_id' => 5,
+            'scope' => 'product',
+            'condition' => [
+                'time' => [
+                    'start' => now()->subHour()->toDateTimeString(),
+                    'end' => now()->addHour()->toDateTimeString(),
+                ],
+                'volume' => [
+                    'min' => 5,
+                    'max' => 20,
+                ],
+            ],
+            'formula' => 'price * 0.8',
+        ]);
+
+        Event::fake();
+        $service = new PricingService;
+        $price = $service->apply(100, $rule->tenant_id, $rule->branch_id, 10);
+
+        Event::assertDispatched(PriceRuleApplied::class);
+        $this->assertSame(80.0, $price);
+    }
+}


### PR DESCRIPTION
## Summary
- add `price_rules` table for branch-specific rule formulas
- dispatch `price.rule_applied` on pricing adjustments
- cover pricing service with unit test

## Testing
- `vendor/bin/pint app/Events/PriceRuleApplied.php app/Models/PriceRule.php app/Services/PricingService.php database/migrations/2024_01_01_100006_create_price_rules_table.php tests/Unit/PricingServiceTest.php -v`
- `vendor/bin/phpstan analyse app tests --no-progress` *(fails: Result is incomplete because of severe errors)*
- `./vendor/bin/pest -q` *(fails: No such file or directory)*
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68bee71dbdd8833282ff7018c4feb0cc