### PR TITLE
feat(analytics): add tenant user aggregation and hub

### DIFF
--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class AnalyticsController extends Controller
+{
+    public function index(Request $request)
+    {
+        $tenantId = $request->user()->tenant_id;
+        $kpi = DB::table('tenant_user_counts')
+            ->where('tenant_id', $tenantId)
+            ->first();
+
+        return view('analytics.index', [
+            'userCount' => $kpi->user_count ?? 0,
+        ]);
+    }
+
+    public function users(Request $request)
+    {
+        $tenantId = $request->user()->tenant_id;
+        $users = DB::table('users')
+            ->where('tenant_id', $tenantId)
+            ->get();
+
+        return view('analytics.users', ['users' => $users]);
+    }
+
+    public function export(Request $request): StreamedResponse
+    {
+        $tenantId = $request->user()->tenant_id;
+        $rows = DB::table('tenant_user_counts')
+            ->where('tenant_id', $tenantId)
+            ->get();
+
+        $response = new StreamedResponse(function () use ($rows) {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, ['tenant_id', 'user_count']);
+            foreach ($rows as $row) {
+                fputcsv($handle, [$row->tenant_id, $row->user_count]);
+            }
+            fclose($handle);
+        });
+
+        $response->headers->set('Content-Type', 'text/csv');
+        $response->headers->set('Content-Disposition', 'attachment; filename="analytics.csv"');
+
+        return $response;
+    }
+}

--- a/database/migrations/2024_01_01_200000_create_tenant_user_counts_view.php
+++ b/database/migrations/2024_01_01_200000_create_tenant_user_counts_view.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(<<<'SQL'
+CREATE OR REPLACE VIEW tenant_user_counts AS
+select tenant_id, count(*) as user_count from users group by tenant_id
+SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS tenant_user_counts');
+    }
+};

--- a/resources/views/analytics/index.blade.php
+++ b/resources/views/analytics/index.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Analytics Hub</title>
+</head>
+<body>
+    <h1>Analytics Hub</h1>
+    <p>Users: {{ $userCount }}</p>
+    <p><a href="{{ route('analytics.users') }}">Drill down to users</a></p>
+    <p><a href="{{ route('analytics.export') }}">Export CSV</a></p>
+</body>
+</html>

--- a/resources/views/analytics/users.blade.php
+++ b/resources/views/analytics/users.blade.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Analytics Users</title>
+</head>
+<body>
+    <h1>Users</h1>
+    <ul>
+        @foreach ($users as $user)
+            <li>{{ $user->email }}</li>
+        @endforeach
+    </ul>
+    <p><a href="{{ route('analytics.index') }}">Back</a></p>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\AnalyticsController;
 use App\Http\Controllers\BillingDashboardController;
 use App\Http\Controllers\FeatureFlagController;
 use App\Http\Controllers\IntegrationManagerController;
@@ -25,6 +26,12 @@ Route::get('/admin/integrations', [IntegrationManagerController::class, 'index']
     ->name('admin.integrations.index');
 Route::post('/admin/integrations', [IntegrationManagerController::class, 'store'])
     ->name('admin.integrations.store');
+
+Route::middleware('auth')->group(function () {
+    Route::get('/analytics', [AnalyticsController::class, 'index'])->name('analytics.index');
+    Route::get('/analytics/users', [AnalyticsController::class, 'users'])->name('analytics.users');
+    Route::get('/analytics/export', [AnalyticsController::class, 'export'])->name('analytics.export');
+});
 
 Route::prefix('api/v1')->group(function () {
     Route::get('tenants/{tenant}/feature-flags', [FeatureFlagController::class, 'index']);


### PR DESCRIPTION
## Summary
- aggregate users per tenant via SQL view
- add AnalyticsHub with KPI, drill-down and export
- wire up routes and basic blades

## Testing
- `vendor/bin/pint app/Http/Controllers/AnalyticsController.php routes/web.php database/migrations/2024_01_01_200000_create_tenant_user_counts_view.php -v`
- `vendor/bin/phpstan analyse app/Http/Controllers/AnalyticsController.php --no-progress`
- `./vendor/bin/pest -q` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bee85a78808332bfc8629698305295