### PR TITLE
Add customer CRM with notifications and import/export

### DIFF
--- a/app/Console/Commands/CustomerAnalyticsReport.php
+++ b/app/Console/Commands/CustomerAnalyticsReport.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CustomerAnalytics;
+use Illuminate\Console\Command;
+
+class CustomerAnalyticsReport extends Command
+{
+    protected $signature = 'crm:analytics';
+
+    protected $description = 'Show basic customer analytics';
+
+    public function handle(CustomerAnalytics $analytics): int
+    {
+        $this->info('Total customers: '.$analytics->totalCustomers());
+        $this->info('Total interactions: '.$analytics->totalInteractions());
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ExportCustomers.php
+++ b/app/Console/Commands/ExportCustomers.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Customer;
+use Illuminate\Console\Command;
+use League\Csv\Writer;
+
+class ExportCustomers extends Command
+{
+    protected $signature = 'crm:export {file}';
+
+    protected $description = 'Export customers to a CSV file';
+
+    public function handle(): int
+    {
+        $path = $this->argument('file');
+        $writer = Writer::createFromPath($path, 'w');
+        $writer->insertOne(['name', 'email', 'phone']);
+
+        Customer::chunk(100, function ($customers) use ($writer) {
+            foreach ($customers as $customer) {
+                $writer->insertOne([$customer->name, $customer->email, $customer->phone]);
+            }
+        });
+
+        $this->info('Customers exported.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ImportCustomers.php
+++ b/app/Console/Commands/ImportCustomers.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Customer;
+use Illuminate\Console\Command;
+use League\Csv\Reader;
+
+class ImportCustomers extends Command
+{
+    protected $signature = 'crm:import {file}';
+
+    protected $description = 'Import customers from a CSV file';
+
+    public function handle(): int
+    {
+        $path = $this->argument('file');
+        $csv = Reader::createFromPath($path, 'r');
+        $csv->setHeaderOffset(0);
+
+        foreach ($csv as $record) {
+            Customer::create([
+                'name' => $record['name'] ?? 'Unknown',
+                'email' => $record['email'] ?? null,
+                'phone' => $record['phone'] ?? null,
+            ]);
+        }
+
+        $this->info('Customers imported.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use App\Notifications\CustomerCreated;
+use App\Support\BelongsToTenant;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Notifiable;
+
+class Customer extends Model
+{
+    use BelongsToTenant, HasFactory, Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'tenant_id',
+    ];
+
+    protected static function booted(): void
+    {
+        static::created(function (Customer $customer) {
+            if ($customer->email) {
+                $customer->notify(new CustomerCreated);
+            }
+        });
+    }
+
+    public function notes()
+    {
+        return $this->hasMany(CustomerNote::class);
+    }
+
+    public function interactions()
+    {
+        return $this->hasMany(CustomerInteraction::class);
+    }
+
+    public function recordInteraction(string $type, ?string $details = null): CustomerInteraction
+    {
+        return $this->interactions()->create([
+            'type' => $type,
+            'details' => $details,
+            'interaction_at' => now(),
+        ]);
+    }
+}

--- a/app/Models/CustomerInteraction.php
+++ b/app/Models/CustomerInteraction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\BelongsToTenant;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomerInteraction extends Model
+{
+    use BelongsToTenant, HasFactory;
+
+    protected $fillable = [
+        'customer_id',
+        'type',
+        'details',
+        'interaction_at',
+        'tenant_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'interaction_at' => 'datetime',
+        ];
+    }
+
+    public function customer()
+    {
+        return $this->belongsTo(Customer::class);
+    }
+}

--- a/app/Models/CustomerNote.php
+++ b/app/Models/CustomerNote.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\BelongsToTenant;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomerNote extends Model
+{
+    use BelongsToTenant, HasFactory;
+
+    protected $fillable = [
+        'customer_id',
+        'note',
+        'tenant_id',
+    ];
+
+    public function customer()
+    {
+        return $this->belongsTo(Customer::class);
+    }
+}

--- a/app/Notifications/CustomerCreated.php
+++ b/app/Notifications/CustomerCreated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class CustomerCreated extends Notification
+{
+    use Queueable;
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Welcome')
+            ->line('Welcome to our platform!');
+    }
+}

--- a/app/Services/CustomerAnalytics.php
+++ b/app/Services/CustomerAnalytics.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Customer;
+
+class CustomerAnalytics
+{
+    public function totalCustomers(): int
+    {
+        return Customer::count();
+    }
+
+    public function totalInteractions(): int
+    {
+        return Customer::withCount('interactions')->get()->sum('interactions_count');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "league/csv": "^9.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac692f06fd43f0588b3eb6502fd4e694",
+    "content-hash": "5f212a58c45fe1e8597b00489937d434",
     "packages": [
         {
             "name": "brick/math",
@@ -1646,6 +1646,97 @@
                 }
             ],
             "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
+            "name": "league/csv",
+            "version": "9.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "e0221a3f16aa2a823047d59fab5809d552e29bc8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/e0221a3f16aa2a823047d59fab5809d552e29bc8",
+                "reference": "e0221a3f16aa2a823047d59fab5809d552e29bc8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1.2"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "ext-xdebug": "*",
+                "friendsofphp/php-cs-fixer": "^3.75.0",
+                "phpbench/phpbench": "^1.4.1",
+                "phpstan/phpstan": "^1.12.27",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.2",
+                "phpstan/phpstan-strict-rules": "^1.6.2",
+                "phpunit/phpunit": "^10.5.16 || ^11.5.22",
+                "symfony/var-dumper": "^6.4.8 || ^7.3.0"
+            },
+            "suggest": {
+                "ext-dom": "Required to use the XMLConverter and the HTMLConverter classes",
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters",
+                "ext-mbstring": "Needed to ease transcoding CSV using mb stream filters",
+                "ext-mysqli": "Requiered to use the package with the MySQLi extension",
+                "ext-pdo": "Required to use the package with the PDO extension",
+                "ext-pgsql": "Requiered to use the package with the PgSQL extension",
+                "ext-sqlite3": "Required to use the package with the SQLite3 extension"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CSV data manipulation made easy in PHP",
+            "homepage": "https://csv.thephpleague.com",
+            "keywords": [
+                "convert",
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "transform",
+                "write"
+            ],
+            "support": {
+                "docs": "https://csv.thephpleague.com",
+                "issues": "https://github.com/thephpleague/csv/issues",
+                "rss": "https://github.com/thephpleague/csv/releases.atom",
+                "source": "https://github.com/thephpleague/csv"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-06-25T14:53:51+00:00"
         },
         {
             "name": "league/flysystem",

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Customer>
+ */
+class CustomerFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->safeEmail(),
+            'phone' => fake()->phoneNumber(),
+        ];
+    }
+}

--- a/database/factories/CustomerInteractionFactory.php
+++ b/database/factories/CustomerInteractionFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\CustomerInteraction>
+ */
+class CustomerInteractionFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'customer_id' => Customer::factory(),
+            'type' => fake()->randomElement(['email', 'call', 'visit']),
+            'details' => fake()->sentence(),
+            'interaction_at' => now(),
+        ];
+    }
+}

--- a/database/factories/CustomerNoteFactory.php
+++ b/database/factories/CustomerNoteFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\CustomerNote>
+ */
+class CustomerNoteFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'customer_id' => Customer::factory(),
+            'note' => fake()->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_200001_create_customers_table.php
+++ b/database/migrations/2024_01_01_200001_create_customers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('customers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'email']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('customers');
+    }
+};

--- a/database/migrations/2024_01_01_200002_create_customer_notes_table.php
+++ b/database/migrations/2024_01_01_200002_create_customer_notes_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('customer_notes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('customer_id')->constrained()->cascadeOnDelete();
+            $table->text('note');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_notes');
+    }
+};

--- a/database/migrations/2024_01_01_200003_create_customer_interactions_table.php
+++ b/database/migrations/2024_01_01_200003_create_customer_interactions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('customer_interactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('customer_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->text('details')->nullable();
+            $table->timestamp('interaction_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_interactions');
+    }
+};

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\Tenant;
+use App\Notifications\CustomerCreated;
+use App\Support\TenantManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class CustomerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_customer_creation_sends_notification(): void
+    {
+        $tenant = Tenant::factory()->create();
+        app(TenantManager::class)->setTenant($tenant);
+        Notification::fake();
+
+        $customer = Customer::factory()->create(['email' => 'jane@example.com']);
+
+        Notification::assertSentTo($customer, CustomerCreated::class);
+        $this->assertDatabaseHas('customers', [
+            'tenant_id' => $tenant->id,
+            'email' => 'jane@example.com',
+        ]);
+    }
+
+    public function test_record_interaction(): void
+    {
+        $tenant = Tenant::factory()->create();
+        app(TenantManager::class)->setTenant($tenant);
+        $customer = Customer::factory()->create();
+
+        $interaction = $customer->recordInteraction('call', 'Discussed order');
+
+        $this->assertDatabaseHas('customer_interactions', [
+            'id' => $interaction->id,
+            'customer_id' => $customer->id,
+            'tenant_id' => $tenant->id,
+            'type' => 'call',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add customer, note, and interaction models with automatic welcome notifications
- provide CSV import/export and analytics console commands
- track customer interactions and expose simple analytics service

## Testing
- `vendor/bin/pint app/Models app/Console/Commands app/Notifications app/Services database/factories database/migrations tests/Feature/CustomerTest.php -v`
- `vendor/bin/phpstan analyse app --no-progress --memory-limit=512M`
- `vendor/bin/pest -q` *(fails: No such file or directory)*
- `vendor/bin/phpunit tests/Feature/CustomerTest.php` *(fails: SQLSTATE[HY000]: General error: 1 near "OR": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68beed6beaa48332af638d5d31127bbf